### PR TITLE
Fix backward pass for hidden state gradient calculation

### DIFF
--- a/SimpleRNN.py
+++ b/SimpleRNN.py
@@ -126,7 +126,7 @@ class SimpleRNN:
         for t in reversed(range(1,self.time_steps+1)):#2 1 0
             
             d_Wih.append((der_chain @ self.Q_intime[t][0].transpose()).transpose())
-            d_Whh.append((der_chain @ self.Q_intime[t][1].transpose()).transpose())
+            d_Whh.append((der_chain @ self.Q_intime[t-1][1].transpose()).transpose())
             d_bh.append(der_chain)
             self.dh_list.append(der_chain)
             der_chain = self.W_hor @ (self.dh_dfi(t-1) * der_chain)


### PR DESCRIPTION
This PR corrects a critical logic L in the Backpropagation Through Time (BPTT) implementation where the hidden-to-hidden weight gradient (W_hh) was calculated using the current hidden state (h_t) instead of the preceding state (h_t-1). Mathematically, the gradient must utilize the source activations (h_t-1) to capture temporal dependencies; using h_t is a fundamental violation of the chain rule that makes the model's learning performance mid. The fix updates the indexing to self.Q_intime[t-1][1], ensuring the backward pass is finally valid and consistent with the forward pass logic.